### PR TITLE
Fix carrito widget query

### DIFF
--- a/app/Filament/Widgets/CarritoWidget.php
+++ b/app/Filament/Widgets/CarritoWidget.php
@@ -17,7 +17,11 @@ class CarritoWidget extends BaseWidget
         // Obtenemos los IDs del carrito desde la sesión
         $carrito = session('carrito', []);
 
-        return Producto::query()->whereIn('id', $carrito);
+        // $carrito es un arreglo asociativo [id => cantidad].
+        // Debemos obtener solo las llaves (IDs) para filtrar
+        $ids = array_keys($carrito);
+
+        return Producto::query()->whereIn('id', $ids);
     }
 
     protected function getTableColumns(): array


### PR DESCRIPTION
## Summary
- fix query for product IDs in `CarritoWidget`

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546f00eb70832c88b467e5ec2f88af